### PR TITLE
fix(beelievers_auction): specify Sui dep in Move.toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,4 @@ add-license:
 
 # used as pre-commit
 lint-git:
-	@git diff --name-only --cached | grep  -E '\.md$$' | xargs -r markdownlint-cli2
-	@git diff --name-only --cached | grep  -E '\.move$$' | xargs -r prettier-move -c
-#	@sui move build --lint
+	@git diff --name-only --cached --diff-filter=ACM | grep  -E '\.md$$' | xargs -r markdownlint-cli2

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ add-license:
 
 # used as pre-commit
 lint-git:
-#	@git diff --name-only --cached | grep  -E '\.md$$' | xargs -r markdownlint-cli2
-#	@git diff --name-only --cached | basedir | xargs -r markdownlint-cli2
-	@sui move build --lint
+	@git diff --name-only --cached | grep  -E '\.md$$' | xargs -r markdownlint-cli2
+	@git diff --name-only --cached | grep  -E '\.move$$' | xargs -r prettier-move -c
+#	@sui move build --lint

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,9 @@ add-license:
 	@awk -i inplace 'FNR==1 && !/SPDX-License-Identifier/ {print "// SPDX-License-Identifier: MPL-2.0\n"}1' */sources/*.move */tests/*.move
 # with reuse tool:
 # docker run --rm --volume $(pwd):/data fsfe/reuse annotate --license MPL-2.0  */tests/*.move */sources/*.move  -s cpp
+
+# used as pre-commit
+lint-git:
+#	@git diff --name-only --cached | grep  -E '\.md$$' | xargs -r markdownlint-cli2
+#	@git diff --name-only --cached | basedir | xargs -r markdownlint-cli2
+	@sui move build --lint

--- a/Makefile-common.mk
+++ b/Makefile-common.mk
@@ -10,16 +10,10 @@ build: .git/hooks/pre-commit
 publish:
 	@sui client publish --skip-dependency-verification  --gas-budget 100000000
 
-# used as pre-commit
-lint-git:
-	@git diff --name-only --cached | grep  -E '\.md$$' | xargs -r markdownlint-cli2
-	@sui move build --lint
-# note: prettier-move is run in the hook directly
-
 # lint changed files
 lint:
 	@git diff --name-only | grep  -E '\.md$$' | xargs -r markdownlint-cli2
-	@ sui move build --lint
+	@sui move build --lint
 
 lint-all:
 	@markdownlint-cli2 **.md

--- a/beelivers_auction/Makefile
+++ b/beelivers_auction/Makefile
@@ -1,0 +1,1 @@
+include ../Makefile-common.mk

--- a/beelivers_auction/Move.lock
+++ b/beelivers_auction/Move.lock
@@ -2,44 +2,22 @@
 
 [move]
 version = 3
-manifest_digest = "3A57C32319F25840D41FE954032E162A23BA808075E42568EF1C21AF007FD19F"
-deps_digest = "F9B494B64F0615AED0E98FC12A85B85ECD2BC5185C22D30E7F67786BB52E507C"
+manifest_digest = "8F2D3B34F1C09E2B953F25915BEA71784D6B6EC9B60C4174F45D1B1356C3A0EC"
+deps_digest = "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082"
 dependencies = [
-  { id = "Bridge", name = "Bridge" },
-  { id = "MoveStdlib", name = "MoveStdlib" },
   { id = "Sui", name = "Sui" },
-  { id = "SuiSystem", name = "SuiSystem" },
-]
-
-[[move.package]]
-id = "Bridge"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "2c930c25f8d3", subdir = "crates/sui-framework/packages/bridge" }
-
-dependencies = [
-  { id = "MoveStdlib", name = "MoveStdlib" },
-  { id = "Sui", name = "Sui" },
-  { id = "SuiSystem", name = "SuiSystem" },
 ]
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "2c930c25f8d3", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "framework/testnet", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "2c930c25f8d3", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "framework/testnet", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
-]
-
-[[move.package]]
-id = "SuiSystem"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "2c930c25f8d3", subdir = "crates/sui-framework/packages/sui-system" }
-
-dependencies = [
-  { id = "MoveStdlib", name = "MoveStdlib" },
-  { id = "Sui", name = "Sui" },
 ]
 
 [move.toolchain-version]

--- a/beelivers_auction/Move.lock
+++ b/beelivers_auction/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "EC1064A71B6E8B695691D0A2357B1DBBFF838415C9A21EFD032C40B0CC226408"
+manifest_digest = "C518C084C56FF74E13884F6F5EF1E684015B060ABA330D4DC422E0AD6B229FB4"
 deps_digest = "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -10,17 +10,17 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "mainnet", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "mainnet", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
 ]
 
 [move.toolchain-version]
-compiler-version = "1.52.2"
+compiler-version = "1.53.2"
 edition = "2024.beta"
 flavor = "sui"

--- a/beelivers_auction/Move.lock
+++ b/beelivers_auction/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "8F2D3B34F1C09E2B953F25915BEA71784D6B6EC9B60C4174F45D1B1356C3A0EC"
+manifest_digest = "EC1064A71B6E8B695691D0A2357B1DBBFF838415C9A21EFD032C40B0CC226408"
 deps_digest = "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -10,17 +10,17 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "framework/testnet", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "framework/testnet", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
 ]
 
 [move.toolchain-version]
-compiler-version = "1.51.1"
+compiler-version = "1.51.2"
 edition = "2024.beta"
 flavor = "sui"

--- a/beelivers_auction/Move.lock
+++ b/beelivers_auction/Move.lock
@@ -21,6 +21,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.51.2"
+compiler-version = "1.52.2"
 edition = "2024.beta"
 flavor = "sui"

--- a/beelivers_auction/Move.toml
+++ b/beelivers_auction/Move.toml
@@ -6,6 +6,8 @@ authors = ["Native"]
 
 [dependencies]
 
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/testnet" }
+
 # For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.
 # Revision can be a branch, a tag, and a commit hash.
 # MyRemotePackage = { git = "https://some.remote/host.git", subdir = "remote/path", rev = "main" }

--- a/beelivers_auction/Move.toml
+++ b/beelivers_auction/Move.toml
@@ -6,7 +6,7 @@ authors = ["Native"]
 
 [dependencies]
 
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "mainnet" }
 
 # For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.
 # Revision can be a branch, a tag, and a commit hash.

--- a/beelivers_auction/Move.toml
+++ b/beelivers_auction/Move.toml
@@ -6,7 +6,7 @@ authors = ["Native"]
 
 [dependencies]
 
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/testnet" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet" }
 
 # For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.
 # Revision can be a branch, a tag, and a commit hash.

--- a/contrib/git-hooks/pre-commit
+++ b/contrib/git-hooks/pre-commit
@@ -9,5 +9,12 @@ if [ -z "$STAGED_MOVE_FILES" ]; then
     exit 0
 fi
 
+for f in $(echo $STAGED_MOVE_FILES | awk -F "/" '{print $1}' | uniq); do
+    echo building and linting $f
+    cd $f
+    sui move build --lint
+    cd -
+done
+
 prettier-move $STAGED_MOVE_FILES --write
 git add $STAGED_MOVE_FILES


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- markdownlint-disable MD012 -->

## Description

Adding `Sui` dependency to `Move.toml` to solve this error:
```
Failed to build Move modules: Failed to resolve dependencies for package 'beelivers_auction'

Caused by:
    0: Parsing manifest for 'Bridge'
    1: No such file or directory (os error 2).
```

## move lint 

It didn't work for with GitHub hooks. 
This PR also contains a fix for that