### PR TITLE
feat: auction finalizer

### DIFF
--- a/beelivers_auction/sources/auction.move
+++ b/beelivers_auction/sources/auction.move
@@ -167,7 +167,8 @@ public fun set_paused(admin_cap: &AdminCap, auction: &mut Auction, pause: bool) 
     auction.paused = pause;
 }
 
-/// Finalizes the auction
+/// Finalizes the auction. Must be chained with finalize_continue* and finalize_end to finish the
+/// process.
 public fun finalize_start(
     admin_cap: &AdminCap,
     auction: &mut Auction,

--- a/beelivers_auction/sources/auction.move
+++ b/beelivers_auction/sources/auction.move
@@ -38,6 +38,8 @@ public struct AdminCap has key, store {
     id: UID,
 }
 
+public struct AuctionFinalizer {}
+
 public struct Auction has key, store {
     id: UID,
     // TODO: consider removing this and use address.
@@ -166,15 +168,14 @@ public fun set_paused(admin_cap: &AdminCap, auction: &mut Auction, pause: bool) 
 }
 
 /// Finalizes the auction
-public entry fun finalize(
+public fun finalize_start(
     admin_cap: &AdminCap,
     auction: &mut Auction,
     // TODO: // we can't do this with 5000+ addresses. sui only can do 16kb size parameter or 500 addresses , https://move-book.com/guides/building-against-limits#single-pure-argument-size. We need to double check PTB can help us in this case or not.
     winners: vector<address>,
     clearing_price: u64,
     clock: &Clock,
-    ctx: &mut TxContext,
-) {
+): AuctionFinalizer {
     assert!(object::id(admin_cap) == auction.admin_cap_id, ENotAdmin);
     assert!(!auction.finalized, EAlreadyFinalized);
     assert!(auction.end_ms <= clock.timestamp_ms(), ENotEnded);
@@ -185,8 +186,32 @@ public entry fun finalize(
     auction.finalized = true;
     auction.clearing_price = clearing_price;
     auction.winners = winners;
+    AuctionFinalizer {}
+}
 
-    let funds = clearing_price * len;
+public fun finalize_continue(
+    finalizer: AuctionFinalizer,
+    auction: &mut Auction,
+    winners: vector<address>,
+): AuctionFinalizer {
+    auction.winners.append(winners);
+
+    finalizer
+}
+
+#[allow(lint(self_transfer))]
+public fun finalize_end(
+    finalizer: AuctionFinalizer,
+    auction: &mut Auction,
+    winners: vector<address>,
+    ctx: &mut TxContext,
+) {
+    // consume finalizer to stop hot potato
+    let AuctionFinalizer {} = finalizer;
+
+    auction.winners.append(winners);
+
+    let funds = auction.clearing_price * auction.winners.length();
     transfer::public_transfer(
         coin::from_balance(auction.vault.split(funds), ctx),
         ctx.sender(),
@@ -195,7 +220,7 @@ public entry fun finalize(
     emit(FinalizedEvent {
         auction_id: auction.id.to_inner(),
         funds,
-        clearing_price,
+        clearing_price: auction.clearing_price,
     });
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- markdownlint-disable MD012 -->

## Description

Use hot potato to chain finalize functions

## Summary by Sourcery

Implement a multi-stage auction finalization process using a hot-potato chaining pattern

New Features:
- Introduce AuctionFinalizer resource and split the single finalize entry into finalize_start, finalize_continue, and finalize_end calls

Enhancements:
- Accumulate winners across chained calls and calculate funds based on the total winners and stored clearing_price
- Update the FinalizedEvent to emit the stored clearing_price and dynamic funds calculation from the auction state