### PR TITLE
feat: add raffle

### DIFF
--- a/beelivers_auction/sources/auction.move
+++ b/beelivers_auction/sources/auction.move
@@ -271,12 +271,12 @@ public entry fun run_raffle(
     let mut raffle_winners: vector<address> = vector[];
     let mut generator = r.new_generator(ctx);
     let mut n = 1;
-    while (n <=num_winners) {
+    while (n <= num_winners) {
         let rnd = generator.generate_u32_in_range(0, max-1);
         let winner = auction.winners[rnd as u64];
         if (!raffle_winners.contains(&winner)) {
             raffle_winners.push_back(winner);
-            n = n +1;
+            n = n + 1;
         }
     };
 

--- a/beelivers_auction/tests/unit_tests.move
+++ b/beelivers_auction/tests/unit_tests.move
@@ -7,7 +7,7 @@ use sui::clock::{Self, Clock};
 use sui::random::{Self, Random};
 use sui::test_scenario as ts;
 
-const ONE_HOUR: u64 = 60 * 60 *1000;
+const ONE_HOUR: u64 = 3600 * 1000;
 
 // fun dummy_tx(sender: address, time_ms: u64): TxContext {
 //     tx_context::new_from_hint(sender, 1, 1, time_ms, 0)


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Description

Adding raffle

## Summary by Sourcery

Implement raffle functionality in the auction module, enabling controlled random selection of winners, tracking raffle state, and covering behavior with new unit tests

New Features:
- Introduce run_raffle entry function to randomly select a subset of auction winners and emit a RaffleResultEvent

Enhancements:
- Add raffle_done flag to Auction struct and change size field from u64 to u32
- Define RaffleResultEvent and new error codes ERaffleTooBig and ERaffleAlreadyDone for raffle validation
- Include set_winners helper for testing purposes
- Update finalize_end and reset_status to incorporate raffle state checks

Tests:
- Add unit test module for raffle logic, including address generation, scenario setup, and test_raffle