### PR TITLE
feat: use redash rather than lodash and improve types

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,6 @@
 
 Beelivers BTCFi activation and NFT auction
 
-## Requirements
-
-- Sui >= v1.52
-- [Bun](https://bun.com/) >= 1.2 -- NOTE: we use bun rather than Node.js
-
 ## Deployed objects & packages
 
 ## Contributing
@@ -16,6 +11,16 @@ Participating in open source is often a highly collaborative experience. We’re
 Check out [contributing repo](https://github.com/gonative-cc/contributig) for our guidelines & policies for how to contribute. Note: we require DCO! Thank you to all those who have contributed!
 
 After cloning the repository, **make sure to run `make setup-hooks`.**
+
+### Requirements
+
+- Sui >= v1.52
+- [Bun](https://bun.com/) >= 1.2 -- NOTE: we use bun rather than Node.js
+- `prettier` and `prettier-move` to format the code.
+
+### Development
+
+- use `bun format:move` or `bun format:move-all` to format your Move code.
 
 ### Security
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,11 +8,10 @@
         "commander": "^14.0.0",
         "csv-parse": "^6.1.0",
         "dotenv": "^17.2.1",
-        "lodash": "^4.17.21",
+        "redash": "^0.23.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
-        "@types/lodash": "^4.17.20",
         "@types/node": "^24.2.1",
         "typescript": "^5.9.2",
       },
@@ -50,8 +49,6 @@
 
     "@types/bun": ["@types/bun@1.2.20", "", { "dependencies": { "bun-types": "1.2.20" } }, "sha512-dX3RGzQ8+KgmMw7CsW4xT5ITBSCrSbfHc36SNT31EOUg/LA9JWq0VDdEXDRSe1InVWpd2yLUM1FUF/kEOyTzYA=="],
 
-    "@types/lodash": ["@types/lodash@4.17.20", "", {}, "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA=="],
-
     "@types/node": ["@types/node@24.3.0", "", { "dependencies": { "undici-types": "~7.10.0" } }, "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow=="],
 
     "@types/react": ["@types/react@19.1.11", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-lr3jdBw/BGj49Eps7EvqlUaoeA0xpj3pc0RoJkHpYaCHkVK7i28dKyImLQb3JVlqs3aYSXf7qYuWOW/fgZnTXQ=="],
@@ -70,9 +67,9 @@
 
     "graphql": ["graphql@16.11.0", "", {}, "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw=="],
 
-    "lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
-
     "poseidon-lite": ["poseidon-lite@0.2.1", "", {}, "sha512-xIr+G6HeYfOhCuswdqcFpSX47SPhm0EpisWJ6h7fHlWwaVIvH3dLnejpatrtw6Xc6HaLrpq05y7VRfvDmDGIog=="],
+
+    "redash": ["redash@0.23.0", "", {}, "sha512-6M9tt7HVvET3rGlIgXng7NzvFRiil5IUqn6W80Sr4bUJm6KMGgzIcSYlj8K+V24xo81kuSTIUmEBOze0/LwfsA=="],
 
     "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
 

--- a/package.json
+++ b/package.json
@@ -19,13 +19,12 @@
     "commander": "^14.0.0",
     "csv-parse": "^6.1.0",
     "dotenv": "^17.2.1",
-    "lodash": "^4.17.21"
+    "redash": "^0.23.0"
   },
   "devDependencies": {
-    "@types/lodash": "^4.17.20",
+    "@types/bun": "latest",
     "@types/node": "^24.2.1",
-    "typescript": "^5.9.2",
-    "@types/bun": "latest"
+    "typescript": "^5.9.2"
   },
   "peerDependencies": {
     "typescript": "^5"

--- a/scripts/beelievers_auction_finalize.ts
+++ b/scripts/beelievers_auction_finalize.ts
@@ -3,7 +3,7 @@ import { isValidSuiAddress } from "@mysten/sui/utils";
 import * as dotenv from "dotenv";
 import { promises as fs } from "fs";
 import { Command } from "commander";
-import _ from "lodash";
+import { chunk } from "radash";
 import { Transaction } from "@mysten/sui/transactions";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 
@@ -87,19 +87,19 @@ export function preprocessAddresses(addresses: string[]): string[] {
 }
 
 export function batchAddresses(addresses: string[], slot: number): string[][] {
-	// split addresses to chuck
 	if (addresses.length == 0) {
-		throw new Error("list address is empty");
+		return [];
 	}
-	return _.chunk(addresses, slot);
+	return chunk(addresses, slot);
 }
 
-async function createPTB(client: SuiClient, keypair: Ed25519Keypair, addresses: string[][]) {
-	let number_txn = addresses.length;
+async function createPTB(client: SuiClient, keypair: Ed25519Keypair, winners: string[][]) {
+	let number_txn = winners.length;
+	if (winners.length === 0) throw Error("winners not selected");
 
-	await start(client, keypair, addresses[0]);
+	await start(client, keypair, winners[0]!);
 	for (let i = 1; i < number_txn; i++) {
-		await next(client, keypair, addresses[i]);
+		await next(client, keypair, winners[i]!);
 	}
 
 	await finalize(client, keypair);


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Description

For modern versions of Node / Bun we don't need to use Lodash. Redash is better - native TS , and leverages ES5.
See: https://radash-docs.vercel.app/docs/getting-started#lodash

> Lodash was incredible. When JavaScript was still maturing, it provided the power to things you couldn’t easily do in the vanilla. That was last decade. In this decade, the needs are different. The goal with Radash is to provide the powerful functions you need, not the ones the runtimes now provide, and to do it with great types and source code that’s easy to read and understand.

## Summary by Sourcery

Replace Lodash with Radash utility functions, strengthen type safety and error handling in auction scripts, and update documentation and dependencies accordingly

Enhancements:
- Replace lodash.chunk with redash.chunk and remove lodash usage in auction finalization script
- Add explicit handling for empty address/winner lists and rename parameters for clarity in createPTB

Build:
- Remove lodash and @types/lodash from package.json and add redash dependency

Documentation:
- Reorganize and expand the README requirements section, including Prettier and Move formatting instructions