### PR TITLE
feat(mint): support future badges

### DIFF
--- a/mint/sources/mint.move
+++ b/mint/sources/mint.move
@@ -334,24 +334,24 @@ module beelievers_mint::mint {
         };
     }
 
-    public entry fun add_future_badges(
+    /// Admin to set new badges to be upserted by an NFT owner.
+    public fun add_future_badges(
         _admin_cap: &AdminCap,
         collection: &mut BeelieversCollection,
         token_id: u64,
         badges: vector<u32>,
     ) {
         if (collection.future_badges.contains(token_id)) {
-            // TODO: test if this works
-            // TODO: check duplications
-            let mut existing = table::borrow_mut(&mut collection.future_badges, token_id);
-            existing.append(badges);
+            let existing = table::borrow_mut(&mut collection.future_badges, token_id);
+            badges.do!(|b|
+                if (!existing.contains(&b)) existing.push_back(b));
         } else {
             table::add(&mut collection.future_badges, token_id, badges);
         };
     }
 
-    /// allows owner of the NFT to upsert new budges
-    public entry fun upsert_nft_badges(nft: &mut BeelieverNFT, c: &BeelieversCollection) {
+    /// Allows NFT owner to upsert new budges
+    public fun upsert_nft_badges(c: &BeelieversCollection, nft: &mut BeelieverNFT) {
         if (!c.future_badges.contains(nft.token_id))
             return;
         c.future_badges[nft.token_id].do!(|b| {
@@ -360,8 +360,6 @@ module beelievers_mint::mint {
                 nft.badges.push_back(name);
         });
     }
-
-
 
 
     public entry fun set_nft_url(
@@ -400,7 +398,10 @@ module beelievers_mint::mint {
             index = index + 1;
         };
     }
-      public entry fun set_bulk_nft_attributes(
+
+
+    /// see set_nft_attributes documentation
+    public entry fun set_bulk_nft_attributes(
         _admin_cap: &AdminCap,
         collection: &mut BeelieversCollection,
         nft_ids: vector<u64>,
@@ -455,9 +456,7 @@ module beelievers_mint::mint {
         };
     }
 
-    // TODO: needs an ability to add new badges in the future, without overwriting.
-
-    // mints an NFT for the ctx sender
+    /// mints an NFT for the ctx sender
     fun mint_for_sender(
         collection: &mut BeelieversCollection,
         probe_idx: u64,

--- a/mint/sources/mint.move
+++ b/mint/sources/mint.move
@@ -467,12 +467,18 @@ module beelievers_mint::mint {
         ctx: &mut TxContext
     ) {
         let recipient = tx_context::sender(ctx);
-        let token_id = collection.remaining_nfts.swap_remove(probe_idx);
+        let token_id = collection.remaining_nfts[probe_idx];
         let nft = collection.create_nft(token_id, recipient, ctx);
 
         let is_mythic = token_id <= MYTHIC_SUPPLY;
         if (is_mythic) {
             collection.remaining_mythic = collection.remaining_mythic - 1;
+            let last_mythic_idx = collection.remaining_mythic-1;
+            if (probe_idx != last_mythic_idx)
+                collection.remaining_nfts.swap(probe_idx, last_mythic_idx);
+            collection.remaining_nfts.swap_remove(last_mythic_idx);
+        } else {
+            collection.remaining_nfts.swap_remove(probe_idx);
         };
 
         event::emit(NFTMinted {

--- a/mint/sources/mint.move
+++ b/mint/sources/mint.move
@@ -335,18 +335,18 @@ module beelievers_mint::mint {
     }
 
     /// Admin to set new badges to be upserted by an NFT owner.
-    public fun add_future_badges(
+    public fun set_future_badges(
         _admin_cap: &AdminCap,
         collection: &mut BeelieversCollection,
-        token_id: u64,
+        nft_id: u64,
         badges: vector<u32>,
     ) {
-        if (collection.future_badges.contains(token_id)) {
-            let existing = table::borrow_mut(&mut collection.future_badges, token_id);
-            badges.do!(|b|
-                if (!existing.contains(&b)) existing.push_back(b));
+        assert!(nft_id > 0 && nft_id <= TOTAL_SUPPLY, EInvalidTokenId);
+
+        if (collection.future_badges.contains(nft_id)) {
+            *table::borrow_mut(&mut collection.future_badges, nft_id) = badges;
         } else {
-            table::add(&mut collection.future_badges, token_id, badges);
+            table::add(&mut collection.future_badges, nft_id, badges);
         };
     }
 

--- a/mint/tests/table_test.move
+++ b/mint/tests/table_test.move
@@ -1,0 +1,33 @@
+module beelievers_mint::table_test;
+
+use sui::table::{Self, Table};
+use sui::test_scenario as ts;
+
+public struct WithTable {
+    badges: Table<u64, vector<u32>>,
+}
+
+#[test]
+fun test_badges_update() {
+    let user = @0x10;
+    let mut ts = ts::begin(user);
+    let mut o = WithTable {
+        badges: table::new(ts.ctx()),
+    };
+    let id = 1;
+    ts.next_tx(@0x11);
+    {
+        o.badges.add(id, vector[1]);
+        let existing = table::borrow_mut(&mut o.badges, id);
+        existing.push_back(22);
+    };
+
+    ts.next_tx(@0x12);
+    {
+        let badges = o.badges[id];
+        assert!(badges == vector[1, 22]);
+    };
+
+    sui::test_utils::destroy(o);
+    ts.end();
+}


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Description

## Summary by Sourcery

Support scheduling and applying badges to NFTs after mint by introducing a future_badges table and corresponding entry functions

New Features:
- Add future_badges table mapping token IDs to badge ID lists for post-mint badge assignment
- Introduce add_future_badges entry function for admins to schedule badges for specific NFTs
- Add upsert_nft_badges entry function to apply scheduled badges to an NFT's badge list

Enhancements:
- Initialize future_badges table in BeelieversCollection during module setup